### PR TITLE
Piz1 fix bug0to get sizes

### DIFF
--- a/app/services/size.py
+++ b/app/services/size.py
@@ -28,3 +28,11 @@ def get_size_by_id(_id: int):
     response = size if not error else {'error': error}
     status_code = 200 if size else 404 if not error else 400
     return jsonify(response), status_code
+
+
+@size.route('/', methods=GET)
+def get_sizes():
+    sizes, error = SizeController.get_all()
+    response = sizes if not error else {'error': error}
+    status_code = 200 if sizes else 404 if not error else 400
+    return jsonify(response), status_code

--- a/app/test/services/test_size.py
+++ b/app/test/services/test_size.py
@@ -1,0 +1,8 @@
+import pytest
+
+def test_get_sizes_service(client, create_sizes, size_uri):
+    response = client.get(size_uri)
+    pytest.assume(response.status.startswith('200'))
+    returned_sizes = {size['_id']: size for size in response.json}
+    for size in create_sizes:
+        pytest.assume(size['_id'] in returned_sizes)


### PR DESCRIPTION
Ticket link:
[PIZ1](https://trello.com/c/dxQZZafX)

Description:
During order creation. I'm unable to complete the order. Moreover, I can't see the pizza sizes. I think that's the problem, as I can't choose the sizes, the order is not created. Please help me to figure out the bug.

Acceptance criteria:
- I should be able to see the pizza sizes
- I should be able to create and order

Test:
To test this PR, you need to create a Ingredient and size objetc before to create an order

Screenshots/Videos:
![image](https://github.com/user-attachments/assets/dd2afe7e-c9a7-4390-bf52-d898b2b7c610)
